### PR TITLE
Fix doc by adding DB_USER and using MD list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ $ dokku help
 Info
 --------
 This plugin adds following envvars to your project automatically:
-DATABASE_URL,DB_HOST,DB_PASSWORD,DB_NAME,DB_PORT
+
+* DATABASE_URL
+* DB_HOST
+* DB_PORT
+* DB_NAME
+* DB_USER
+* DB_PASSWORD
 
 Simple usage
 ------------


### PR DESCRIPTION
The doc is missing the `DB_USER` env var and does not properly use markdown for these vars. I corrected it as these are really important.
