### PR TITLE
When re-creating an already existing database, use -f to tag.

### DIFF
--- a/commands
+++ b/commands
@@ -55,7 +55,7 @@ case "$1" in
     ID=$(docker run -d kloadut/mariadb /bin/bash "exit 0")
     docker wait $ID > /dev/null
     IMAGE=$(docker commit $ID)
-    docker tag $IMAGE $DB_IMAGE
+    docker tag -f $IMAGE $DB_IMAGE
     # Launch container
     ID=$(docker run -v $VOLUME -p 172.17.42.1::3306 -d $DB_IMAGE /usr/bin/start_mariadb.sh $DB_PASSWORD)
     sleep 4


### PR DESCRIPTION
After a restart, my database container was suddenly missing, so I tried to re-create it. But I got the following error:
```
$ dokku mariadb:create portfolio

-----> Reusing mariadb/portfolio database
FATA[0000] Error response from daemon: Conflict: Tag latest is already set to image 93fff006badedf59e3408b6c2413cd7238d16bca2d3cb901851e14c796880d47, if you want to replace it, please use -f option 
```
With -f, everything seems to work fine, but I'm not a docker expert...