### PR TITLE
Fixed volume deletion #12

### DIFF
--- a/commands
+++ b/commands
@@ -86,7 +86,7 @@ case "$1" in
     if [[ ! -z $ID ]]; then
         docker kill $ID > /dev/null
         sleep 1
-        docker rm $ID > /dev/null
+        docker rm -v $ID > /dev/null
         sleep 1
     fi
     # Remove image

--- a/commands
+++ b/commands
@@ -104,9 +104,17 @@ case "$1" in
     fi
     # Remove persistent volume
     if [[ -f "$DOKKU_ROOT/.mariadb/volume_$APP" ]]; then
+        VOLUME="$(cat $DOKKU_ROOT/.mariadb/volume_$APP)"
         sleep 4
-        rm -rf "$(cat $DOKKU_ROOT/.mariadb/volume_$APP)"
+        
+        if [[ -d "$VOLUME" ]]; then
+            echo "-----> Persistant Storage cannot be deleted !"
+            echo "---------> Linkfile 'DOKKU_ROOT/.mariadb/volume_$APP' won't be deleted"
+            exit 1
+        fi
+        
         rm -f "$DOKKU_ROOT/.mariadb/volume_$APP"
+
     fi
     echo
     echo "-----> MariaDB container deleted: $DB_IMAGE"


### PR DESCRIPTION
This fixes #12 

The user "dokku" cannot access nor delete from `/var/lib/docker/vfs/dir/`.
Docker itself can do that with the command `docker rm -v`

```
Usage: docker rm [OPTIONS] CONTAINER [CONTAINER...]

Remove one or more containers

  -f, --force=false      Force the removal of a running container (uses SIGKILL)
  --help=false           Print usage
  -l, --link=false       Remove the specified link and not the underlying container
  -v, --volumes=false    Remove the volumes associated with the container
```