### PR TITLE
Add missing plugin.toml description file

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,4 @@
+[plugin]
+description = "MariaDB plugin for Dokku"
+version = "0.1.0"
+[plugin.config]

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,4 @@
 [plugin]
-description = "MariaDB plugin for Dokku"
+description = "dokku mariadb plugin"
 version = "0.1.0"
 [plugin.config]


### PR DESCRIPTION
Adding plugin.toml gets rid of 'file not found' errors during dokku deploys
