### PR TITLE
Add missing plugin.toml for 0.4.0+ support

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,5 @@
+[plugin]
+description = "MariaDB plugin for Dokku"
+version = "0.0.0"
+[plugin.config]
+


### PR DESCRIPTION
As of 0.4.0+ a plugin.toml is required to prevent errors.

http://dokku.viewdocs.io/dokku~v0.4.14/development/plugin-creation/
